### PR TITLE
Architecture Module Foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny_computers"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tiny_computers"
-version = "0.1.2"
+name = "tiny_emu_lib"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/src/arch/chip_8/mod.rs
+++ b/src/arch/chip_8/mod.rs
@@ -1,0 +1,518 @@
+use crate::core::cpu::CpuState;
+use crate::core::cpu::CpuStateError;
+use crate::core::isa::{InstructionCodec, InstructionSet};
+use crate::{
+    arch::error::ArchError,
+    core::{
+        cpu::{Cpu, CpuError, FlagsRegister, RegisterError, RegisterFile},
+        isa::{AddressingError, AddressingMode, Instruction, InstructionError},
+        memory::{MemoryDevice, MemoryError},
+    },
+};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
+
+pub enum Chip8Error {
+    Cpu(CpuError),
+    Memory(MemoryError),
+    Instruction(InstructionError),
+    InvalidState(String),
+    UnsupportedFeature(String),
+    TimingViolation,
+    Register(RegisterError),
+}
+
+impl From<ArchError> for Chip8Error {
+    fn from(err: ArchError) -> Self {
+        match err {
+            ArchError::Cpu(err) => Self::Cpu(err),
+            ArchError::Memory(err) => Self::Memory(err),
+            ArchError::Instruction(err) => Self::Instruction(err),
+            ArchError::InvalidState(msg) => Self::InvalidState(msg),
+            ArchError::UnsupportedFeature(feature) => Self::UnsupportedFeature(feature),
+            ArchError::TimingViolation => Self::TimingViolation,
+        }
+    }
+}
+
+impl From<CpuError> for Chip8Error {
+    fn from(err: CpuError) -> Self {
+        Self::Cpu(err)
+    }
+}
+
+impl From<Chip8Error> for CpuError {
+    fn from(err: Chip8Error) -> Self {
+        match err {
+            Chip8Error::Cpu(cpu_err) => cpu_err,
+            Chip8Error::Memory(_) => {
+                Self::State(CpuStateError::InvalidState("Memory error".into()))
+            }
+            Chip8Error::Instruction(_) => {
+                Self::State(CpuStateError::InvalidState("Instruction error".into()))
+            }
+            Chip8Error::InvalidState(msg) => Self::State(CpuStateError::InvalidState(msg)),
+            Chip8Error::UnsupportedFeature(msg) => Self::State(CpuStateError::InvalidState(msg)),
+            Chip8Error::TimingViolation => {
+                Self::State(CpuStateError::InvalidState("Timing violation".into()))
+            }
+            Chip8Error::Register(_register_error) => todo!(),
+        }
+    }
+}
+
+impl From<InstructionError> for Chip8Error {
+    fn from(err: InstructionError) -> Self {
+        Self::Instruction(err)
+    }
+}
+
+impl From<CpuStateError> for Chip8Error {
+    fn from(err: CpuStateError) -> Self {
+        Self::Cpu(CpuError::State(err))
+    }
+}
+
+impl From<RegisterError> for Chip8Error {
+    fn from(err: RegisterError) -> Self {
+        Self::Register(err)
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct Chip8Instruction(u16); // CHIP-8 uses 16-bit instructions
+
+#[derive(Debug)]
+pub struct Chip8 {
+    _cpu: Chip8Cpu,
+    _memory: Chip8Memory,
+}
+
+#[derive(Debug)]
+pub struct Chip8Cpu {
+    state: Chip8State, // Add a state field to hold the current state
+}
+
+impl Cpu for Chip8Cpu {
+    type Error = Chip8Error;
+    type ISA = Chip8InstructionSet;
+    type State = Chip8State;
+
+    fn instruction_set(&self) -> &Self::ISA {
+        todo!()
+    }
+
+    fn state(&self) -> &Self::State {
+        &self.state
+    }
+
+    fn state_mut(&mut self) -> &mut Self::State {
+        &mut self.state
+    }
+
+    fn reset(&mut self) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn step(&mut self) -> Result<u8, Self::Error> {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub struct Chip8Memory {
+    memory: [u8; 4096],
+}
+
+impl Chip8Memory {
+    pub fn new() -> Self {
+        Self { memory: [0; 4096] }
+    }
+
+    pub fn read_slice(&self, address: u16, length: usize) -> Result<&[u8], Chip8Error> {
+        if address as usize + length > self.memory.len() {
+            return Err(Chip8Error::Memory(MemoryError::AddressOutOfBounds));
+        }
+        Ok(&self.memory[address as usize..address as usize + length])
+    }
+}
+
+impl Default for Chip8Memory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryDevice for Chip8Memory {
+    type Error = Chip8Error;
+
+    type Address = u16;
+
+    type Word = u8;
+
+    fn read(&self, address: Self::Address) -> Result<Self::Word, Self::Error> {
+        Ok(self.memory[address as usize])
+    }
+
+    fn write(&mut self, address: Self::Address, value: Self::Word) -> Result<(), Self::Error> {
+        self.memory[address as usize] = value;
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        todo!()
+    }
+
+    fn size(&self) -> usize {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub enum Chip8AddressingMode {
+    Immediate,
+    Register,
+    Indirect,
+    Direct,
+}
+
+impl AddressingMode for Chip8AddressingMode {
+    type Register = u8;
+
+    type Address = u16;
+
+    type Error = AddressingError;
+
+    fn resolve(&self, _cpu: &impl CpuState) -> Result<Self::Address, Self::Error> {
+        todo!()
+    }
+
+    fn size(&self) -> usize {
+        todo!()
+    }
+
+    fn format(&self) -> String {
+        todo!()
+    }
+
+    fn is_valid_register(
+        &self,
+        _register: <Chip8AddressingMode as AddressingMode>::Register,
+    ) -> bool {
+        todo!()
+    }
+
+    fn is_valid_address(&self, _address: Self::Address) -> bool {
+        todo!()
+    }
+
+    fn bytes_needed(&self) -> usize {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub enum Chip8InstructionSet {
+    Chip8,
+    SuperChip,
+    XOChip,
+}
+
+pub struct Chip8Inst(u16);
+
+impl Instruction for Chip8Inst {
+    type Error = Chip8Error;
+    type Opcode = u8;
+    type Register = u8;
+    type Address = u16;
+    type Word = u8;
+
+    type AddressingMode = Chip8AddressingMode;
+
+    fn execute(
+        &self,
+        _cpu: &mut impl CpuState,
+        _memory: &mut impl MemoryDevice<
+            Address = Self::Address,
+            Word = <Self as Instruction>::Word,
+            Error = <Self as Instruction>::Error,
+        >,
+    ) -> Result<u8, <Self as Instruction>::Error> {
+        todo!()
+    }
+
+    fn cycles(&self) -> u8 {
+        todo!()
+    }
+
+    fn affects_flags(&self) -> bool {
+        todo!()
+    }
+
+    fn disassemble(&self) -> String {
+        todo!()
+    }
+}
+
+impl InstructionSet for Chip8InstructionSet {
+    type Error = Chip8Error;
+    type Instruction = Chip8Inst;
+    type Opcode = u8;
+    type Register = u8; // CHIP-8 uses 8-bit registers
+    type Address = u16; // CHIP-8 uses 16-bit addresses
+    type Word = u8; // CHIP-8 uses 8-bit words
+
+    fn name(&self) -> &str {
+        todo!()
+    }
+
+    fn word_size(&self) -> u8 {
+        todo!()
+    }
+
+    fn address_size(&self) -> u8 {
+        todo!()
+    }
+
+    fn register_count(&self) -> usize {
+        todo!()
+    }
+
+    fn is_valid_opcode(&self, _opcode: Self::Opcode) -> bool {
+        todo!()
+    }
+
+    fn categorize(&self, _opcode: Self::Opcode) -> crate::core::isa::InstructionCategory {
+        todo!()
+    }
+
+    fn opcodes_in_category(
+        &self,
+        _category: crate::core::isa::InstructionCategory,
+    ) -> Vec<Self::Opcode> {
+        todo!()
+    }
+}
+
+impl InstructionCodec for Chip8Inst {
+    type Error = Chip8Error;
+    type Word = u8;
+
+    fn encode(&self) -> Vec<u8> {
+        let bytes = self.0.to_be_bytes();
+        vec![bytes[0], bytes[1]]
+    }
+
+    fn decode(bytes: &[Self::Word]) -> Result<Self, Self::Error> {
+        if bytes.len() < 2 {
+            return Err(Chip8Error::Instruction(InstructionError::InvalidLength));
+        }
+        Ok(Self((bytes[0] as u16) << 8 | bytes[1] as u16))
+    }
+    fn size(&self) -> usize {
+        todo!()
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Chip8FlagsRegister(u8);
+
+impl Not for Chip8FlagsRegister {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Chip8FlagsRegister(!self.0)
+    }
+}
+
+impl BitOrAssign for Chip8FlagsRegister {
+    fn bitor_assign(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+}
+
+impl BitAndAssign for Chip8FlagsRegister {
+    fn bitand_assign(&mut self, other: Self) {
+        self.0 &= other.0;
+    }
+}
+
+impl BitAnd for Chip8FlagsRegister {
+    type Output = Self;
+
+    fn bitand(self, other: Self) -> Self::Output {
+        Chip8FlagsRegister(self.0 & other.0)
+    }
+}
+
+impl BitOr for Chip8FlagsRegister {
+    type Output = Self;
+
+    fn bitor(self, other: Self) -> Self::Output {
+        Chip8FlagsRegister(self.0 | other.0)
+    }
+}
+
+impl FlagsRegister for Chip8FlagsRegister {
+    fn get(&self) -> u8 {
+        self.0
+    }
+
+    fn set(&mut self, value: u8) {
+        self.0 = value;
+    }
+
+    fn update(&mut self, mask: u8, value: u8) {
+        self.0 = (self.0 & !mask) | (value & mask);
+    }
+
+    fn test(&self, mask: u8) -> bool {
+        (self.0 & mask) != 0
+    }
+}
+
+#[derive(Debug)]
+pub struct Chip8RegisterFile {
+    _registers: [u8; 16],
+    _i: u16,
+    _pc: u16,
+    _sp: u16,
+    _dt: u8,
+    _st: u8,
+}
+
+impl RegisterFile for Chip8RegisterFile {
+    type Error = Chip8Error;
+    type Index = u8;
+    type Flags = Chip8FlagsRegister;
+    type Word = u8;
+    type Address = u16;
+
+    fn get(&self, _index: Self::Index) -> Result<Self::Word, Self::Error> {
+        todo!()
+    }
+
+    fn set(&mut self, _index: Self::Index, _value: Self::Word) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn registers(&self) -> &[Self::Word] {
+        todo!()
+    }
+
+    fn registers_mut(&mut self) -> &mut [Self::Word] {
+        todo!()
+    }
+
+    fn register_count(&self) -> usize {
+        todo!()
+    }
+
+    fn program_counter(&self) -> Self::Address {
+        todo!()
+    }
+
+    fn set_program_counter(&mut self, _value: Self::Address) {
+        todo!()
+    }
+
+    fn stack_pointer(&self) -> Self::Address {
+        todo!()
+    }
+
+    fn set_stack_pointer(&mut self, _value: Self::Address) {
+        todo!()
+    }
+
+    fn flags(&self) -> Self::Flags {
+        todo!()
+    }
+
+    fn update_flags(&mut self, _mask: Self::Flags, _value: Self::Flags) {
+        todo!()
+    }
+
+    fn reset(&mut self) {
+        todo!()
+    }
+
+    fn test_flags(&self, _mask: Self::Flags) -> bool {
+        (self.flags() & _mask) == _mask
+    }
+}
+
+#[derive(Debug)]
+pub struct Chip8State {
+    register_file: Chip8RegisterFile,
+}
+
+impl CpuState for Chip8State {
+    type Address = u16; // CHIP-8 uses 16-bit addresses
+    type Word = u8; // CHIP-8 uses 8-bit words
+    type Memory = Chip8Memory;
+    type Error = Chip8Error;
+    type Register = u8; // CHIP-8 uses 8-bit registers
+
+    fn read_register(&self, _reg: Self::Register) -> Result<Self::Word, Self::Error> {
+        todo!()
+    }
+
+    fn write_register(
+        &mut self,
+        _reg: Self::Register,
+        _value: Self::Word,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn get_program_counter(&self) -> Self::Address {
+        todo!()
+    }
+
+    fn set_program_counter(&mut self, _addr: Self::Address) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn get_stack_pointer(&self) -> Self::Address {
+        todo!()
+    }
+
+    fn set_stack_pointer(&mut self, _addr: Self::Address) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn get_flags(&self) -> u8 {
+        todo!()
+    }
+
+    fn set_flags(&mut self, _flags: u8) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn test_flag(&self, _flag: u8) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    fn memory(&self) -> &Self::Memory {
+        todo!()
+    }
+
+    fn memory_mut(&mut self) -> &mut Self::Memory {
+        todo!()
+    }
+
+    fn cycles(&self) -> u64 {
+        todo!()
+    }
+
+    fn add_cycles(&mut self, _cycles: u8) {
+        todo!()
+    }
+}
+
+impl Chip8State {
+    pub fn pc(&self) -> u16 {
+        self.register_file._pc // Assuming `pc` is a field in `Chip8RegisterFile`
+    }
+}

--- a/src/arch/error.rs
+++ b/src/arch/error.rs
@@ -1,0 +1,54 @@
+use crate::core::{cpu::CpuError, isa::InstructionError, memory::MemoryError};
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ArchError {
+    /// CPU-related errors
+    Cpu(CpuError),
+
+    /// Memory-related errors
+    Memory(MemoryError),
+
+    /// Instruction-related errors
+    Instruction(InstructionError),
+
+    /// Architecture-specific errors
+    InvalidState(String),
+    UnsupportedFeature(String),
+    TimingViolation,
+}
+
+impl Display for ArchError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Cpu(err) => write!(f, "CPU error: {}", err),
+            Self::Memory(err) => write!(f, "Memory error: {}", err),
+            Self::Instruction(err) => write!(f, "Instruction error: {}", err),
+            Self::InvalidState(msg) => write!(f, "Invalid state: {}", msg),
+            Self::UnsupportedFeature(feature) => write!(f, "Unsupported feature: {}", feature),
+            Self::TimingViolation => write!(f, "Timing violation"),
+        }
+    }
+}
+
+impl Error for ArchError {}
+
+// Implement From for core error types
+impl From<CpuError> for ArchError {
+    fn from(err: CpuError) -> Self {
+        Self::Cpu(err)
+    }
+}
+
+impl From<MemoryError> for ArchError {
+    fn from(err: MemoryError) -> Self {
+        Self::Memory(err)
+    }
+}
+
+impl From<InstructionError> for ArchError {
+    fn from(err: InstructionError) -> Self {
+        Self::Instruction(err)
+    }
+}

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,0 +1,55 @@
+pub mod chip_8;
+pub mod error;
+
+use crate::core::{
+    cpu::{Cpu, CpuState},
+    isa::InstructionSet,
+    memory::MemoryDevice,
+};
+
+use error::ArchError;
+use std::fmt::Debug;
+
+pub use chip_8::Chip8;
+
+/// Represents a CPU architecture implementation
+pub trait Architecture: Debug {
+    /// Architecture-specific error type
+    type Error: From<ArchError>;
+    /// CPU implementation for this architecture
+    type CPU: Cpu<Error = Self::Error>;
+    /// Instruction set for this architecture
+    type ISA: InstructionSet<Error = Self::Error>;
+    /// CPU state for this architecture
+    type State: CpuState<Error = Self::Error>;
+    /// Memory implementation for this architecture
+    type Memory: MemoryDevice<Error = Self::Error>;
+
+    /// Returns the name of this architecture
+    fn name(&self) -> &str;
+
+    /// Returns the CPU implementation
+    fn cpu(&self) -> &Self::CPU;
+
+    /// Returns a mutable reference to the CPU
+    fn cpu_mut(&mut self) -> &mut Self::CPU;
+
+    /// Returns the memory implementation
+    fn memory(&self) -> &Self::Memory;
+
+    /// Returns a mutable reference to memory
+    fn memory_mut(&mut self) -> &mut Self::Memory;
+
+    /// Resets the architecture to its initial state
+    fn reset(&mut self) -> Result<(), Self::Error>;
+
+    /// Executes one instruction
+    /// Returns the number of cycles taken
+    fn step(&mut self) -> Result<u8, Self::Error>;
+
+    /// Returns the current state
+    fn state(&self) -> &Self::State;
+
+    /// Returns the instruction set
+    fn instruction_set(&self) -> &Self::ISA;
+}

--- a/src/core/cpu/error.rs
+++ b/src/core/cpu/error.rs
@@ -11,7 +11,7 @@ pub enum RegisterError {
     AccessError(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CpuStateError {
     Register(RegisterError),
     Memory(MemoryError),
@@ -19,7 +19,7 @@ pub enum CpuStateError {
     InvalidState(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CpuError {
     State(CpuStateError),
     Halted,

--- a/src/core/isa/error.rs
+++ b/src/core/isa/error.rs
@@ -12,6 +12,8 @@ pub enum InstructionError {
     InvalidOpcode,
     /// The value is not valid for this operation
     InvalidValue,
+    /// The length of the instruction is invalid
+    InvalidLength,
     /// An addressing error occurred
     AddressingError(AddressingError),
 }
@@ -30,6 +32,7 @@ impl Display for InstructionError {
         match self {
             Self::InvalidOpcode => write!(f, "Invalid opcode"),
             Self::InvalidValue => write!(f, "Invalid value"),
+            Self::InvalidLength => write!(f, "Invalid length"),
             Self::AddressingError(e) => write!(f, "Addressing error: {}", e),
         }
     }

--- a/src/core/isa/mod.rs
+++ b/src/core/isa/mod.rs
@@ -44,7 +44,7 @@ mod instruction;
 pub use addressing::AddressingMode;
 pub use category::InstructionCategory;
 pub use codec::InstructionCodec;
-pub use error::InstructionError;
+pub use error::{AddressingError, InstructionError};
 pub use instruction::Instruction;
 
 /// Represents a complete instruction set architecture (ISA)

--- a/src/core/memory/error.rs
+++ b/src/core/memory/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
 /// Represents errors that can occur during memory operations
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MemoryError {
     /// Attempted to access an address outside the valid range
     AddressOutOfBounds,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod arch;
 pub mod core;


### PR DESCRIPTION
Closes #1

## Overview
Implements the base architecture module with core traits and error types for different CPU architectures.

## Changes

### New Files
- `src/arch/mod.rs`: Base module and exports
- `src/arch/error.rs`: Architecture error types
- `src/arch/traits.rs`: Core architecture traits
- `src/arch/chip_8: Module for a CHIP-8 implementation